### PR TITLE
Upgrade to gtkd 3.0.0 to be able use dmd 2.067

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,7 +5,7 @@
 	"license": "BSL-1.0",
 	"authors": ["klickverbot"],
 	"dependencies": {
-		"gtk-d": "~>2.4.2"
+		"gtk-d": "~>3.0.0"
 	},
 	"targetType": "library"
 }

--- a/source/plot2kill/gtkwrapper.d
+++ b/source/plot2kill/gtkwrapper.d
@@ -1091,7 +1091,7 @@ class TickDialog(char xy) : Dialog {
         checkHbox.add(gridLineButton);
 
         auto intensLabel = new Label("Gridline Intensity (0-255)");
-        intensLabel.setJustify(GtkJustification.JUSTIFY_RIGHT);
+        intensLabel.setJustify(GtkJustification.RIGHT);
         checkHbox.add(intensLabel);
 
         gridEntry = new Entry();


### PR DESCRIPTION
Package cannot be built with gtkd `2.4.2` (warnings and errors), but with `3.0.0` version everything is OK.
